### PR TITLE
Feature/docker

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+node_modules
+dist
+Dockerfile
+docker-compose.yml
+*.md 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,22 @@
+FROM node:lts-alpine
+
+LABEL version="1.0"
+LABEL description="Api de l'application GestionEnqueteur"
+
+WORKDIR /app
+
+COPY . .
+
+RUN npm install 
+
+ENV MONGO_HOST="mongo"
+ENV MONGO_PORT="27017"
+ENV MONGO_USER="root"
+ENV MONGO_PASSWORD="example"
+ENV MONGO_URL="mongodb://root:example@mongo:27017/"
+
+EXPOSE 3000
+
+CMD ["npm", "run", "dev"]
+
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,12 +1,18 @@
-# Use root/example as user/password credentials
 version: "3.1"
 
 services:
+  api:
+    build: .
+    restart: always
+    ports:
+      - 3000:3000
+    volumes:
+      - ./src:/app/src
+      - ./test:/app/test
+
   mongo:
     image: mongo
     restart: always
-    ports:
-      - 27017:27017
     environment:
       MONGO_INITDB_ROOT_USERNAME: root
       MONGO_INITDB_ROOT_PASSWORD: example


### PR DESCRIPTION
Création d'un réseau de container qui contient 3 container : 
- **mongo** : le service BDD 
- **mongo-express**: service pour administrer la BDD avec une interface web ( mise sur le port : 8081 ) [mongo-express](http://127.0.0.1:8081)
- **api**: notre propre Api que nous allons développer, écoute sur le port 3000 [Api](http://127.0.0.1:3000)

j'ai paramétré le container Api pour qui fait un montage du dossier `/app/src` et let dossier `/app/test` pour qui le monte sur le dossier `<dossierDeTravail>/apiGestionEnqueuteur` et `<dossierDeTravail>/apiGestionEnqeuteur` de la machine host ( Le PC ) . 

## Prérequis

-  [Docker](https://www.docker.com/)

## Lancement du réseau de container 

1. pour lancer le réseau de container, taper à la racine du projet : `docker-compose up` ( _vous pouvez ajouter le paramètre **-d** à la fin de la commande pour le lancer en mode détacher ( non attaché au terminal )

si lancé en mode détaché, vous pouvez arrêter le réseau de container en tapant : 
`docker-compose down` 